### PR TITLE
feat(validation): [BACK-1393] Validate Rest Query Params

### DIFF
--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -1,4 +1,3 @@
-import * as Sentry from '@sentry/node';
 import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 import gql from 'graphql-tag';
 import fetch from 'cross-fetch';
@@ -21,31 +20,15 @@ export async function getStories(
   date: string,
   scheduledSurfaceID: string
 ): Promise<BrazeContentProxyResponse> {
-  let data: ClientApiResponse | null = null;
-
   // Validate inputs
-  try {
-    await validateScheduledSurfaceGuid(scheduledSurfaceID);
-  } catch (err) {
-    console.log(err);
-    Sentry.captureException(err);
-  }
-
-  try {
-    await validateDate(date);
-  } catch (err) {
-    console.log(err);
-    Sentry.captureException(err);
-  }
+  validateScheduledSurfaceGuid(scheduledSurfaceID);
+  validateDate(date);
 
   // Retrieve data
-  try {
-    data = await getData(date, scheduledSurfaceID);
-  } catch (err) {
-    console.log('Error retrieving Pocket Hits data!');
-    console.log(err);
-    Sentry.captureException(err);
-  }
+  const data: ClientApiResponse | null = await getData(
+    date,
+    scheduledSurfaceID
+  );
 
   return {
     stories: data ? data.data.scheduledSurface.items : [],
@@ -84,13 +67,9 @@ async function getData(
   });
 
   if (!data.data?.scheduledSurface?.items) {
-    Sentry.captureException(
-      new Error(
-        `No data returned for ${scheduledSurfaceID} scheduled on ${date}.`
-      )
+    throw new Error(
+      `No data returned for ${scheduledSurfaceID} scheduled on ${date}.`
     );
-
-    return null;
   }
 
   return data;

--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -4,6 +4,7 @@ import gql from 'graphql-tag';
 import fetch from 'cross-fetch';
 import config from './config';
 import { BrazeContentProxyResponse, ClientApiResponse } from './types';
+import { validateDate, validateScheduledSurfaceGuid } from './utils';
 
 const client = new ApolloClient({
   link: new HttpLink({ fetch, uri: 'https://client-api.getpocket.com' }),
@@ -22,6 +23,22 @@ export async function getStories(
 ): Promise<BrazeContentProxyResponse> {
   let data: ClientApiResponse | null = null;
 
+  // Validate inputs
+  try {
+    await validateScheduledSurfaceGuid(scheduledSurfaceID);
+  } catch (err) {
+    console.log(err);
+    Sentry.captureException(err);
+  }
+
+  try {
+    await validateDate(date);
+  } catch (err) {
+    console.log(err);
+    Sentry.captureException(err);
+  }
+
+  // Retrieve data
   try {
     data = await getData(date, scheduledSurfaceID);
   } catch (err) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,7 +48,7 @@ interface BrazePocketHitsQuery {
   date: string;
 }
 
-app.get('/scheduled-items/:scheduledSurfaceID?date=:date', async (req, res) => {
+app.get('/scheduled-items/:scheduledSurfaceID', async (req, res) => {
   // enable 30 minute cache when in AWS
   if (config.app.environment !== 'development') {
     res.set('Cache-control', 'public, max-age=1800');

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,0 +1,45 @@
+import { validateDate, validateScheduledSurfaceGuid } from './utils';
+
+describe('function validateScheduledSurfaceGuid', () => {
+  it('Allows a valid Pocket Hits surface', () => {
+    expect(() => {
+      validateScheduledSurfaceGuid('POCKET_HITS_EN_US');
+    }).not.toThrow();
+  });
+
+  it('Disallows an empty string', () => {
+    expect(() => {
+      validateScheduledSurfaceGuid('');
+    }).toThrowError('Not a valid Scheduled Surface');
+  });
+
+  it('Disallows an invalid surface GUID', () => {
+    expect(() => {
+      validateScheduledSurfaceGuid('MADE_UP_GUID_GOES_HERE');
+    }).toThrowError('Not a valid Scheduled Surface.');
+  });
+});
+
+describe('function validateDate', () => {
+  it('Allows a date in YYYY-MM-DD format', () => {
+    expect(() => {
+      validateDate('2050-01-01');
+    }).not.toThrow();
+  });
+
+  it('Disallows an empty date value', () => {
+    expect(() => {
+      validateDate('');
+    }).toThrowError(
+      'Not a valid date. Please provide a date in YYYY-MM-DD format.'
+    );
+  });
+
+  it('Disallows a date in invalid format', () => {
+    expect(() => {
+      validateDate('29 Jan, 1900');
+    }).toThrowError(
+      'Not a valid date. Please provide a date in YYYY-MM-DD format.'
+    );
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,28 +1,28 @@
 /**
- *
+ * Check if the scheduled surface GUID provided is on the list
+ * of surfaces needed by Braze.
  *
  * @param name
  */
-export async function validateScheduledSurfaceGuid(
-  name: string
-): Promise<void> {
+export function validateScheduledSurfaceGuid(name: string): void {
   const allowlist = ['POCKET_HITS_EN_US', 'POCKET_HITS_DE_DE'];
 
   if (allowlist.includes(name)) {
     return;
   } else {
-    throw new Error('Not a valid Scheduled Surface');
+    throw new Error('Not a valid Scheduled Surface.');
   }
 }
 
 /**
+ * Check if the date string provided is in YYYY-MM-DD format.
  *
  * @param date
  */
-export async function validateDate(date: string): Promise<void> {
+export function validateDate(date: string): void {
   const regEx = /^\d{4}-\d{2}-\d{2}$/;
 
-  if (date.match(regEx) === null) {
+  if (!date || date.match(regEx) === null) {
     throw new Error(
       'Not a valid date. Please provide a date in YYYY-MM-DD format.'
     );

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,32 @@
+/**
+ *
+ *
+ * @param name
+ */
+export async function validateScheduledSurfaceGuid(
+  name: string
+): Promise<void> {
+  const allowlist = ['POCKET_HITS_EN_US', 'POCKET_HITS_DE_DE'];
+
+  if (allowlist.includes(name)) {
+    return;
+  } else {
+    throw new Error('Not a valid Scheduled Surface');
+  }
+}
+
+/**
+ *
+ * @param date
+ */
+export async function validateDate(date: string): Promise<void> {
+  const regEx = /^\d{4}-\d{2}-\d{2}$/;
+
+  if (date.match(regEx) === null) {
+    throw new Error(
+      'Not a valid date. Please provide a date in YYYY-MM-DD format.'
+    );
+  }
+
+  return;
+}


### PR DESCRIPTION
## Goal

Add validation to the two variables the endpoint accepts: scheduled surface GUID and date. 

## I'd love feedback/perspectives on:
- How and where Sentry should be involved. 

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1393
