### PR TITLE
fix(proxy): actually return data + move validation call

### DIFF
--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -3,7 +3,6 @@ import gql from 'graphql-tag';
 import fetch from 'cross-fetch';
 import config from './config';
 import { BrazeContentProxyResponse, ClientApiResponse } from './types';
-import { validateDate, validateScheduledSurfaceGuid } from './utils';
 
 const client = new ApolloClient({
   link: new HttpLink({ fetch, uri: 'https://client-api.getpocket.com' }),
@@ -20,10 +19,6 @@ export async function getStories(
   date: string,
   scheduledSurfaceID: string
 ): Promise<BrazeContentProxyResponse> {
-  // Validate inputs
-  validateScheduledSurfaceGuid(scheduledSurfaceID);
-  validateDate(date);
-
   // Retrieve data
   const data: ClientApiResponse | null = await getData(
     date,

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import https from 'https';
 import express from 'express';
 import config from './config';
 import { getStories } from './client-api-proxy';
+import { validateDate, validateScheduledSurfaceGuid } from './utils';
 
 // TODO: copy .aws directory from client-api
 
@@ -86,9 +87,13 @@ app.get('/scheduled-items/:scheduledSurfaceID', async (req, res, next) => {
   // Get the date the stories are scheduled for
   const date = req.query.date as string;
 
-  // Fetch the data
   try {
-    res.json(await getStories(date, scheduledSurfaceID));
+    // Validate inputs
+    validateScheduledSurfaceGuid(scheduledSurfaceID);
+    validateDate(date);
+
+    // Fetch data
+    return res.json(await getStories(date, scheduledSurfaceID));
   } catch (err) {
     // Let Express handle any errors
     next(err);


### PR DESCRIPTION
## Goal

A follow-up to https://github.com/Pocket/braze-content-proxy/pull/15 based on feedback in Slack after the merge. 

- Added returning the data (🤦!!!)
- Moved validation call out of `getStories` function.
