### PR TITLE
fix(express): [BACK-1421] Fix endpoint and custom error handler

### DIFF
--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -17,12 +17,12 @@ const client = new ApolloClient({
  */
 export async function getStories(
   date: string,
-  scheduledSurfaceID: string
+  scheduledSurfaceId: string
 ): Promise<BrazeContentProxyResponse> {
   // Retrieve data
   const data: ClientApiResponse | null = await getData(
     date,
-    scheduledSurfaceID
+    scheduledSurfaceId
   );
 
   return {
@@ -36,7 +36,7 @@ export async function getStories(
  */
 async function getData(
   date: string,
-  scheduledSurfaceID: string
+  scheduledSurfaceId: string
 ): Promise<ClientApiResponse | null> {
   const data = await client.query({
     query: gql`
@@ -57,13 +57,13 @@ async function getData(
     `,
     variables: {
       date,
-      scheduledSurfaceID,
+      scheduledSurfaceId,
     },
   });
 
   if (!data.data?.scheduledSurface?.items) {
     throw new Error(
-      `No data returned for ${scheduledSurfaceID} scheduled on ${date}.`
+      `No data returned for ${scheduledSurfaceId} scheduled on ${date}.`
     );
   }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -39,37 +39,6 @@ AWSXRay.middleware.enableDynamicNaming('*');
 
 app.use(express.json());
 
-/**
- * Use a custom error handler.
- *
- * Note: this middleware call needs to be placed last,
- * that is, below all other `app.use()` calls.
- *
- */
-app.use((err, req, res, next) => {
-  if (res.headersSent) {
-    return next(err);
-  }
-
-  // Log error to CloudWatch
-  console.log(err);
-
-  // Send error to Sentry
-  Sentry.captureException(err);
-
-  /**
-   * If Pocket Hits stories are unavailable for whatever reason, the emails
-   * should not be sent out. To achieve this, Braze needs to receive a 500 or 502
-   * error if anything is amiss - if a 404 error is sent instead, Braze will
-   * render an empty string and proceed with sending out the email.
-   *
-   * See Braze docs on Connected Content:
-   * https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/connected_content/making_an_api_call/
-   */
-  res.status(500);
-  res.render('error', { error: err });
-});
-
 app.get('/.well-known/server-health', (req, res) => {
   res.status(200).send('ok');
 });
@@ -102,6 +71,36 @@ app.get('/scheduled-items/:scheduledSurfaceID', async (req, res, next) => {
 
 //Make sure the express app has the xray close segment handler
 app.use(xrayExpress.closeSegment());
+
+/**
+ * Use a custom error handler.
+ *
+ * Note: this middleware call needs to be placed last,
+ * that is, below all other `app.use()` calls.
+ *
+ */
+app.use((err, req, res, next) => {
+  if (res.headersSent) {
+    return next(err);
+  }
+
+  // Log error to CloudWatch
+  console.log(err);
+
+  // Send error to Sentry
+  Sentry.captureException(err);
+
+  /**
+   * If Pocket Hits stories are unavailable for whatever reason, the emails
+   * should not be sent out. To achieve this, Braze needs to receive a 500 or 502
+   * error if anything is amiss - if a 404 error is sent instead, Braze will
+   * render an empty string and proceed with sending out the email.
+   *
+   * See Braze docs on Connected Content:
+   * https://www.braze.com/docs/user_guide/personalization_and_dynamic_content/connected_content/making_an_api_call/
+   */
+  res.status(500).json({ error: err.message });
+});
 
 app
   .listen({ port: config.app.port }, () => {


### PR DESCRIPTION
## Goal

- Fixed a variable name in query sent to Client API - now receiving data.

- Fixed custom error handler - it should be added _after_ all other `.use()` calls and routes.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1421
