### PR TITLE
feat(images): [BACK-1432] Resize thumbnail images to 150x150

### DIFF
--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -25,8 +25,21 @@ export async function getStories(
     scheduledSurfaceId
   );
 
+  const stories = data ? data.data.scheduledSurface.items : [];
+
+  // Resize images on the fly so that
+  // they don't distort emails
+  // when sent out.
+  // (Was that a haiku?)
+  stories.forEach(function (part, index) {
+    this[index].imageUrl =
+      `https://pocket-image-cache.com/150x150/filters:format(jpeg):quality(100):no_upscale():strip_exif()/`.concat(
+        encodeURIComponent(this[index].imageUrl)
+      );
+  }, stories);
+
   return {
-    stories: data ? data.data.scheduledSurface.items : [],
+    stories,
   };
 }
 

--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -33,7 +33,7 @@ export async function getStories(
   // (Was that a haiku?)
   stories.forEach(function (part, index) {
     this[index].imageUrl =
-      `https://pocket-image-cache.com/150x150/filters:format(jpeg):quality(100):no_upscale():strip_exif()/`.concat(
+      `${config.images.protocol}://${config.images.host}/${config.images.width}x${config.images.height}/filters:${config.images.filters}/`.concat(
         encodeURIComponent(this[index].imageUrl)
       );
   }, stories);

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -5,6 +5,14 @@ export default {
     version: `${process.env.GIT_SHA ?? 'local'}`,
     port: 4500,
   },
+  // Params we call Pocket Image Cache with to resize story thumbnails on the fly.
+  images: {
+    protocol: 'https',
+    host: 'pocket-image-cache.com',
+    width: 150,
+    height: 150,
+    filters: 'format(jpeg):quality(100):no_upscale():strip_exif()',
+  },
   sentry: {
     dsn: process.env.SENTRY_DSN || '',
     release: process.env.GIT_SHA || '',


### PR DESCRIPTION
## Goal

We need to make sure images served through Braze Content Proxy are constrained to 150x150 so that they don't distort the Pocket Hits emails in some email clients, and also load faster by virtue of being smaller in size than the original thumbnails. 

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1432
