### PR TITLE
feat(caching): [BACK-1429] Implement caching

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -46,9 +46,11 @@ app.get('/.well-known/server-health', (req, res) => {
 // This is the one and only endpoint planned for this repository,
 // so a separate controller is not necessary.
 app.get('/scheduled-items/:scheduledSurfaceID', async (req, res, next) => {
-  // enable 30 minute cache when in AWS
+  // Enable two minute cache when in AWS.
+  // The short-lived cache is to speed up the curators' workflow
+  // if they need to make last-minute updates.
   if (config.app.environment !== 'development') {
-    res.set('Cache-control', 'public, max-age=1800');
+    res.set('Cache-control', 'public, max-age=120');
   }
 
   // Get the scheduled surface GUID


### PR DESCRIPTION
## Goal

Update the default caching on the REST API to be two minutes maximum. This is to speed up the curators' workflow if they need to make last-minute changes to stories scheduled for Pocket Hits emails.


## I'd love feedback/perspectives on:
- Is updating the `max-age` value in the `Cache-control` header the only thing that needs to be done here?

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1429