### PR TITLE
feat(authors): [BACK-1435] Add authors to result set.

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,12 @@
 /**
- * A very lean Curated Item type with just the data Pocket Hits emails need.
+ * The properties of curated items that we need to fetch from Client API.
  */
 export type CuratedItem = {
   url: string;
   title: string;
   excerpt: string;
   imageUrl: string;
-  // TODO: add it when it is available on Curated Corpus API
-  // author: string;
+  authors: { name: string };
   publisher: string;
 };
 
@@ -24,8 +23,18 @@ export type ClientApiResponse = {
 };
 
 /**
+ * A very lean Curated Item type with just the data Pocket Hits emails need.
+ *
+ * Unlike in the Client API response, the Braze Content Proxy response contains
+ * a string that lists all the authors for each story, not an object.
+ */
+export type TransformedCuratedItem = Omit<CuratedItem, 'authors'> & {
+  authors: string;
+};
+
+/**
  * The response we serve from this proxy for Braze.
  */
 export type BrazeContentProxyResponse = {
-  stories: CuratedItem[];
+  stories: TransformedCuratedItem[];
 };


### PR DESCRIPTION
## Goal

As it turned out, we _must_ provide authors for stories that are featured in Pocket Hits emails! Now that the work on Prospect API and Curated Corpus API to support authors is done, we can add this functionality to Braze Content Proxy.

- Updated query to Client API to include authors for curated corpus stories scheduled onto Pocket Hits surfaces.

- Updated REST response to include comma-separated authors returned by Client API.

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1435
