### PR TITLE
fix(authors): [BACK-1447] Fix proxy output

### DIFF
--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -5,7 +5,7 @@ import config from './config';
 import {
   BrazeContentProxyResponse,
   ClientApiResponse,
-  TransformedCuratedItem,
+  TransformedCorpusItem,
 } from './types';
 
 const client = new ApolloClient({
@@ -31,19 +31,21 @@ export async function getStories(
 
   const stories = data ? data.data.scheduledSurface.items : [];
 
-  const transformedStories: TransformedCuratedItem[] = stories.map(function (
+  const transformedStories: TransformedCorpusItem[] = stories.map(function (
     item,
     index
   ) {
     return {
-      ...item,
+      ...item.corpusItem,
       // Resize images on the fly so that they don't distort emails when sent out.
       imageUrl:
         `${config.images.protocol}://${config.images.host}/${config.images.width}x${config.images.height}/filters:${config.images.filters}/`.concat(
           encodeURIComponent(this[index].imageUrl)
         ),
       // Flatten the authors into a comma-separated string.
-      authors: this[index].authors.map((author) => author.name).join(', '),
+      authors: this[index].corpusItem.authors
+        ?.map((author) => author.name)
+        .join(', '),
     };
   },
   stories);

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 /**
  * The properties of curated items that we need to fetch from Client API.
  */
-export type CuratedItem = {
+export type CorpusItem = {
   url: string;
   title: string;
   excerpt: string;
@@ -10,6 +10,10 @@ export type CuratedItem = {
   publisher: string;
 };
 
+export interface ScheduledSurfaceItem {
+  corpusItem: CorpusItem;
+}
+
 /**
  * The shape of the query returned by Client API that contains curated items
  * scheduled for a given day on a given Pocket Hits surface.
@@ -17,18 +21,18 @@ export type CuratedItem = {
 export type ClientApiResponse = {
   data: {
     scheduledSurface: {
-      items: CuratedItem[];
+      items: ScheduledSurfaceItem[];
     };
   };
 };
 
 /**
- * A very lean Curated Item type with just the data Pocket Hits emails need.
+ * A very lean Corpus Item type with just the data Pocket Hits emails need.
  *
  * Unlike in the Client API response, the Braze Content Proxy response contains
  * a string that lists all the authors for each story, not an object.
  */
-export type TransformedCuratedItem = Omit<CuratedItem, 'authors'> & {
+export type TransformedCorpusItem = Omit<CorpusItem, 'authors'> & {
   authors: string;
 };
 
@@ -36,5 +40,5 @@ export type TransformedCuratedItem = Omit<CuratedItem, 'authors'> & {
  * The response we serve from this proxy for Braze.
  */
 export type BrazeContentProxyResponse = {
-  stories: TransformedCuratedItem[];
+  stories: TransformedCorpusItem[];
 };


### PR DESCRIPTION
## Goal

While pairing with @Herraj testing out the Braze feed on Dev, we have found a bug whereby the shape of the data returned was totally wrong and the feed itself was dying on an error with an array thanks to this.

- Updated the output to serve the authors correctly, as a comma-separated string.

- Updated types, brought types in line with returned types from Client API

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1447