### PR TITLE
fix(inmemory cache): [BACK-1449]: Remove in memory cache for apollo client

### DIFF
--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -14,6 +14,14 @@ const client = new ApolloClient({
   cache: new InMemoryCache(),
   name: config.app.apolloClientName,
   version: config.app.version,
+  defaultOptions: {
+    watchQuery: {
+      fetchPolicy: 'no-cache',
+    },
+    query: {
+      fetchPolicy: 'no-cache',
+    },
+  },
 });
 
 /**


### PR DESCRIPTION
## Goal

We were getting some stale/cached results intermittently from this service. Turns out we had `in-memory` cache enabled for our `ApolloClient` instance.

**NOTE:** the constructor for `ApolloClient` requires the `cache` property but we can pass in a `defaultOptions` property (this change) or pass in a `fetchpolicy` for each separate request to use the `no-cache` directive.


JIRA ticket:
* [BACK-1449]

[BACK-1449]: https://getpocket.atlassian.net/browse/BACK-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ