### PR TITLE
feat(output): [BACK-1450] Include item id in proxy output

### DIFF
--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -75,6 +75,7 @@ async function getData(
         scheduledSurface(id: $scheduledSurfaceId) {
           items(date: $date) {
             corpusItem {
+              id
               url
               title
               excerpt

--- a/src/client-api-proxy.ts
+++ b/src/client-api-proxy.ts
@@ -45,6 +45,9 @@ export async function getStories(
     index
   ) {
     return {
+      // The id of the Scheduled Surface Item
+      id: item.id,
+      // Properties of the Corpus Item the proxy needs to make available for Braze
       ...item.corpusItem,
       // Resize images on the fly so that they don't distort emails when sent out.
       imageUrl: getResizedImageUrl(this[index].corpusItem.imageUrl),
@@ -74,8 +77,8 @@ async function getData(
       query PocketHits($date: Date!, $scheduledSurfaceId: ID!) {
         scheduledSurface(id: $scheduledSurfaceId) {
           items(date: $date) {
+            id
             corpusItem {
-              id
               url
               title
               excerpt

--- a/src/main.integration.ts
+++ b/src/main.integration.ts
@@ -26,6 +26,7 @@ describe('main.integration.ts', () => {
     const testStories = {
       stories: [
         {
+          id: '123-abc',
           url: 'www.test-url.com',
           title: 'test-title',
           excerpt: 'test-excerpt',
@@ -34,6 +35,7 @@ describe('main.integration.ts', () => {
           publisher: 'test-publisher',
         },
         {
+          id: '456-cde',
           url: 'www.second-test-url.com',
           title: 'second-test-title',
           excerpt: 'second-test-excerpt',

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
  * The properties of curated items that we need to fetch from Client API.
  */
 export type CorpusItem = {
+  id: string;
   url: string;
   title: string;
   excerpt: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,6 @@
  * The properties of curated items that we need to fetch from Client API.
  */
 export type CorpusItem = {
-  id: string;
   url: string;
   title: string;
   excerpt: string;
@@ -12,6 +11,7 @@ export type CorpusItem = {
 };
 
 export interface ScheduledSurfaceItem {
+  id: string;
   corpusItem: CorpusItem;
 }
 
@@ -29,12 +29,13 @@ export type ClientApiResponse = {
 
 /**
  * A very lean Corpus Item type with just the data Pocket Hits emails need.
- *
- * Unlike in the Client API response, the Braze Content Proxy response contains
- * a string that lists all the authors for each story, not an object.
  */
 export type TransformedCorpusItem = Omit<CorpusItem, 'authors'> & {
+  // Unlike in the Client API response, the Braze Content Proxy response contains
+  // a string that lists all the authors for each story, not an object.
   authors: string;
+  // This value is the id of the Scheduled Surface Item, rather than the Corpus Item
+  id: string;
 };
 
 /**


### PR DESCRIPTION
## Goal

We're including the external ID of the scheduled surface item in the proxy output as discussed in Slack. 

Note that the public query returns the external ID simply as `id` and we're following these naming conventions (unlike in Admin API where it would be `externalId` throughout).

## References

JIRA ticket:
* https://getpocket.atlassian.net/browse/BACK-1450
