### PR TITLE
chore(CircleCI): Remove package caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,13 +53,6 @@ jobs:
       # Define the working directory for this job
       - attach_workspace:
           at: /tmp/workspace
-      - restore_cache:
-          keys:
-            # when lock file changes, use increasingly general patterns to restore cache
-            # If this gets our of sync, you can increment the version (vX).  Just be
-            # sure to match that version when saving the cache as well.
-            - node-v1-{{ checksum "package-lock.json" }}
-            - node-v1-
       # Add user to npmrc
       - run:
           name: Authenticate with GitHub package registry
@@ -67,11 +60,6 @@ jobs:
       - run:
           name: install node modules
           command: npm ci
-      # Save the cache to avoid extraneous downloads
-      - save_cache:
-          key: node-v1-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
       - run:
           name:
           command: |
@@ -103,24 +91,12 @@ jobs:
           AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            # when lock file changes, use increasingly general patterns to restore cache
-            # If this gets our of sync, you can increment the version (vX).  Just be
-            # sure to match that version when saving the cache as well.
-            - node-v1-{{ checksum "package-lock.json" }}
-            - node-v1-
       - run:
           name: Authenticate with GitHub package registry
           command: echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" > ~/.npmrc
       - run:
           name: install node modules
           command: npm ci
-      # Save the cache to avoid extraneous downloads
-      - save_cache:
-          key: node-v1-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
       - run:
           name: run tests
           command: |
@@ -139,24 +115,12 @@ jobs:
           AWS_XRAY_CONTEXT_MISSING: LOG_ERROR
     steps:
       - checkout
-      - restore_cache:
-          keys:
-            # when lock file changes, use increasingly general patterns to restore cache
-            # If this gets our of sync, you can increment the version (vX).  Just be
-            # sure to match that version when saving the cache as well.
-            - node-v1-{{ checksum "package-lock.json" }}
-            - node-v1-
       - run:
           name: Authenticate with GitHub package registry
           command: echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" > ~/.npmrc
       - run:
           name: install node modules
           command: npm ci
-      # Save the cache to avoid extraneous downloads
-      - save_cache:
-          key: node-v1-{{ checksum "package-lock.json" }}
-          paths:
-            - ./node_modules
       - run:
           name: run tests
           command: npm run test


### PR DESCRIPTION
## Goal

Remove caching of NPM packages that we don't use anyway. Double-checked that `npm ci`, rather than `npm install`, is used throughout the config file.

## Reference

https://getpocket.atlassian.net/wiki/spaces/PE/pages/2950561920/2023+April+CI+CD+DevOps+Day