### PR TITLE
feat(collection-stories): expose shortUrl for collection stories

### DIFF
--- a/src/graphql/client-api-proxy.ts
+++ b/src/graphql/client-api-proxy.ts
@@ -44,6 +44,9 @@ export async function getCollectionsFromGraph(slug: string): Promise<any> {
             authors {
               name
             }
+            item {
+              shortUrl
+            }
             url
           }
         }

--- a/src/routes/collection.ts
+++ b/src/routes/collection.ts
@@ -44,11 +44,15 @@ export async function getCollection(slug: string) {
 function transformToBrazePayload(response): BrazeCollections {
   const collection = response.data.getCollectionBySlug;
   const stories = collection.stories.map((story) => {
-    return {
+    const res = {
       ...story,
       imageUrl: getResizedImageUrl(story.imageUrl),
       authors: story.authors.map((author) => author.name),
+      shortUrl: story.item.shortUrl,
     };
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { item: _, ...rest } = res;
+    return rest;
   });
   return {
     ...collection,

--- a/src/routes/fixture.ts
+++ b/src/routes/fixture.ts
@@ -15,6 +15,10 @@ export const graphCollectionFixture = {
       stories: [
         {
           externalId: '0bc6487f-adad-4971-934b-85bae9852fbd',
+          item: {
+            shortUrl: 'https://pocket.co/x_JA',
+            __typename: 'Item',
+          },
           title: 'Labor Exploitation, Explained by Minions',
           url: 'https://www.vox.com/the-goods/23177505/minions-2-rise-of-gru-explained-capitalism',
           excerpt:
@@ -35,6 +39,10 @@ export const graphCollectionFixture = {
           externalId: '994b8b75-6730-4758-b926-e05d5eea9867',
           title: 'The Rise and Fall of the Pop Star Purity Ring',
           url: 'https://jezebel.com/the-rise-and-fall-of-the-pop-star-purity-ring-1822170318',
+          item: {
+            shortUrl: 'https://pocket.co/x_AB',
+            __typename: 'Item',
+          },
           excerpt: 'this is a text with lot of words. and interesting story',
           imageUrl:
             'https://s3.amazonaws.com/pocket-collectionapi-prod-images/609a0ffd-d9af-4cda-b911-9e40397611bc.jpeg',
@@ -57,12 +65,16 @@ export const brazeCollectionsFixture: BrazeCollections = Object.freeze({
   ),
   stories: graphCollectionFixture.data.getCollectionBySlug.stories.map(
     (story) => {
-      return {
+      const res = {
         ...story,
         //this method is unit tested, so using it in fixture
         imageUrl: getResizedImageUrl(story.imageUrl),
+        shortUrl: story.item.shortUrl,
         authors: story.authors.map((author) => author.name),
       };
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { item: _, ...rest } = res;
+      return rest;
     }
   ),
 });

--- a/src/routes/types.ts
+++ b/src/routes/types.ts
@@ -50,6 +50,7 @@ export type BrazeCollections = {
 type BrazeCollectionStory = {
   title: string;
   url: string;
+  shortUrl: string;
   excerpt: string;
   imageUrl: string;
   publisher: string;


### PR DESCRIPTION
## Goal
feat(collection-stories): expose shortUrl for collection stories


### why?
- new pocket hits design will share collection stories. when user clicks on this from email, they should open within pocket app for mobile users
- not exposing for collections itself as they are internal domain. [slack thread](https://pocket.slack.com/archives/C046NLE4XS5/p1682510200645369)

[dev test  - shared url pointing to dev db](https://pocket-dev.postman.co/workspace/Pocket~5b389395-697a-44ae-bcfd-3ff592fd249c/request/16399619-2131e3e1-5328-4587-9e52-45e427f9c46b)

Ticket: https://getpocket.atlassian.net/browse/UJM-116