### PR TITLE
feat(surface): removing validator on the surface ids

### DIFF
--- a/src/routes/scheduledItems.integration.ts
+++ b/src/routes/scheduledItems.integration.ts
@@ -63,16 +63,6 @@ describe('/scheduled-items/:scheduledSurfaceID?date=date&apikey=apikey', () => {
     expect(response.statusCode).equals(404);
   });
 
-  it('should return 500 if incorrect scheduled surface is provided ', async () => {
-    const response = await requestAgent.get(
-      `/scheduled-items/NEW_TAB_DOES_NOT_EXIST`,
-    );
-
-    expect(response.statusCode).equals(500);
-    expect(response.body.error).to.not.be.undefined;
-    expect(response.body.error).to.equal('Not a valid Scheduled Surface.');
-  });
-
   it('should return 500 if incorrect date format is provided ', async () => {
     const response = await requestAgent.get(
       `/scheduled-items/${testNewTab}?date=20220524`,

--- a/src/routes/scheduledItems.ts
+++ b/src/routes/scheduledItems.ts
@@ -1,11 +1,6 @@
 import { BrazeContentProxyResponse, TransformedCorpusItem } from './types';
 import { ClientApiResponse } from '../graphql/types';
-import {
-  getResizedImageUrl,
-  validateApiKey,
-  validateDate,
-  validateScheduledSurfaceGuid,
-} from '../utils';
+import { getResizedImageUrl, validateApiKey, validateDate } from '../utils';
 import { getScheduledSurfaceStories } from '../graphql/client-api-proxy';
 import config from '../config';
 import { Router } from 'express';
@@ -29,7 +24,6 @@ router.get('/:scheduledSurfaceID', async (req, res, next) => {
 
   try {
     // Validate inputs
-    validateScheduledSurfaceGuid(scheduledSurfaceID);
     validateDate(date);
     await validateApiKey(apiKey);
 

--- a/src/utils.spec.ts
+++ b/src/utils.spec.ts
@@ -1,30 +1,5 @@
 import config from './config';
-import {
-  validateDate,
-  validateScheduledSurfaceGuid,
-  validateApiKey,
-  getResizedImageUrl,
-} from './utils';
-
-describe('function validateScheduledSurfaceGuid', () => {
-  it('Allows a valid Pocket Hits surface', () => {
-    expect(() => {
-      validateScheduledSurfaceGuid('POCKET_HITS_EN_US');
-    }).not.toThrow();
-  });
-
-  it('Disallows an empty string', () => {
-    expect(() => {
-      validateScheduledSurfaceGuid('');
-    }).toThrowError('Not a valid Scheduled Surface');
-  });
-
-  it('Disallows an invalid surface GUID', () => {
-    expect(() => {
-      validateScheduledSurfaceGuid('MADE_UP_GUID_GOES_HERE');
-    }).toThrowError('Not a valid Scheduled Surface.');
-  });
-});
+import { validateDate, validateApiKey, getResizedImageUrl } from './utils';
 
 describe('function validateDate', () => {
   it('Allows a date in YYYY-MM-DD format', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,16 +6,6 @@
  */
 import config from './config';
 
-export function validateScheduledSurfaceGuid(name: string): void {
-  const allowlist = ['POCKET_HITS_EN_US', 'POCKET_HITS_DE_DE'];
-
-  if (allowlist.includes(name)) {
-    return;
-  } else {
-    throw new Error('Not a valid Scheduled Surface.');
-  }
-}
-
 /**
  * Check if the date string provided is in YYYY-MM-DD format.
  *


### PR DESCRIPTION
## Goal

Remove the validator on the surface id so that Editorial can use any surface that exists in our systems.
